### PR TITLE
use default location of synapseLogin credentials as configPath input …

### DIFF
--- a/buildConsensusModules.R
+++ b/buildConsensusModules.R
@@ -45,7 +45,7 @@ if (nc > 2){
 registerDoParallel(cl)
 
 #### Login to synapse ####
-synapseLogin(configPath = configPath)
+synapseLogin()
 
 #### Get the latest commit of used files from github ####
 thisRepo <- githubr::getRepo(repository = repository, ref = "branch", refName = branchName)


### PR DESCRIPTION
…is no longer supported by the synapseClient.